### PR TITLE
Added NormalizedString to be used as key in maps

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -195,6 +195,12 @@ func TestParser(t *testing.T) {
 	invalid("1.2.3.")
 }
 
+func TestNilVersionStringOutput(t *testing.T) {
+	var nilVersion *Version
+	require.Equal(t, "", nilVersion.String())
+	require.Equal(t, "", string(nilVersion.NormalizedString()))
+}
+
 func TestParseRelaxed(t *testing.T) {
 	bad := ParseRelaxed("bad")
 	require.Nil(t, bad.version)

--- a/parser_test.go
+++ b/parser_test.go
@@ -18,6 +18,7 @@ func TestParser(t *testing.T) {
 		v, err := Parse(in)
 		require.NoError(t, err, "parsing '%s'", in)
 		require.Equal(t, in, v.String(), "printing of '%s'", in)
+		require.Equal(t, normalized, string(v.NormalizedString()), "normalized printing of '%s'", in)
 		dump := string(v.major) + ","
 		dump += string(v.minor) + ","
 		dump += string(v.patch)

--- a/relaxed_version.go
+++ b/relaxed_version.go
@@ -42,6 +42,19 @@ func (v *RelaxedVersion) String() string {
 	return string(v.customversion)
 }
 
+// NormalizedString return a string representation of the version that is
+// normalized (always have a major, minor and patch version when semver compliant).
+// This is useful to be used in maps and other places where the version is used as a key.
+func (v *RelaxedVersion) NormalizedString() NormalizedString {
+	if v == nil {
+		return ""
+	}
+	if v.version != nil {
+		return v.version.NormalizedString()
+	}
+	return NormalizedString(v.customversion)
+}
+
 // CompareTo compares the RelaxedVersion with the one passed as parameter.
 // Returns -1, 0 or 1 if the version is respectively less than, equal
 // or greater than the compared Version

--- a/relaxed_version_test.go
+++ b/relaxed_version_test.go
@@ -128,4 +128,7 @@ func TestRelaxedCompatibleWith(t *testing.T) {
 func TestNilRelaxedVersionString(t *testing.T) {
 	var nilVersion *RelaxedVersion
 	require.Equal(t, "", nilVersion.String())
+	require.Equal(t, "", string(nilVersion.NormalizedString()))
+	require.Equal(t, "1.0.0", string(ParseRelaxed("1.0.0").NormalizedString()))
+	require.Equal(t, "invalid-semver", string(ParseRelaxed("invalid-semver").NormalizedString()))
 }

--- a/version.go
+++ b/version.go
@@ -46,6 +46,53 @@ func (v *Version) String() string {
 	return res
 }
 
+// NormalizedString is a datatype to be used in maps and other places where the
+// version is used as a key.
+type NormalizedString string
+
+// NormalizedString return a string representation of the version that is
+// normalized to always have a major, minor and patch version. This is useful
+// to be used in maps and other places where the version is used as a key.
+func (v *Version) NormalizedString() NormalizedString {
+	if v == nil {
+		return ""
+	}
+	res := NormalizedString("")
+	if len(v.major) > 0 {
+		res += NormalizedString(v.major)
+	} else {
+		res += "0"
+	}
+
+	if len(v.minor) > 0 {
+		res += "." + NormalizedString(v.minor)
+	} else {
+		res += ".0"
+	}
+	if len(v.patch) > 0 {
+		res += "." + NormalizedString(v.patch)
+	} else {
+		res += ".0"
+	}
+	for i, prerelease := range v.prerelases {
+		if i == 0 {
+			res += "-"
+		} else {
+			res += "."
+		}
+		res += NormalizedString(prerelease)
+	}
+	for i, build := range v.builds {
+		if i == 0 {
+			res += "+"
+		} else {
+			res += "."
+		}
+		res += NormalizedString(build)
+	}
+	return res
+}
+
 var zero = []byte("0")
 
 // Normalize transforms a truncated semver version in a strictly compliant semver


### PR DESCRIPTION
Sometimes it's useful to have a map like `map[string]*Release` that maps a version to the corresponding release. Anyway, this has a drawback, if the version is not normalized before being assigned as a key we may end up having something like:

```
"1.0": &Release{...},
"1.0.0": &Release{...},
```

where two different entries are present for the same version.
To avoid this kind of problem this PR adds a new type `NormalizedString`, so the previous map can be rewritten as `map[semver.NormalizedString]*Release`. To obtain the normalized string the method `Version.NormalizedString()` can be used.

```go
releases := map[semver.NormalizedString]*Release{}

v10 := semver.MustParse("1.0")
releases[v10.NormalizedString()] = release1

v100 := semver.MustParse("1.0.0")
releases[v100.NormalizedString()] = release2  // replaces "release1"

r := releases[v10.NormalizedString()] // gets "release2"
fmt.Println(v10.Equal(v100)) // prints "true"
```

it also helps with a compile-time sanity check on code doing the wrong thing:

```go
releases[v10.String()] = release1
// error: cannot use v10.String() (value of type string) as semver.NormalizedString value in map
```
