### PR TITLE
Speedup dependency resolver by pre-cutting unsolvable branches

### DIFF
--- a/resolver_test.go
+++ b/resolver_test.go
@@ -94,12 +94,13 @@ func TestResolver(t *testing.T) {
 	d100 := rel("D", "1.0.0", deps())
 	d120 := rel("D", "1.2.0", deps("E"))
 	e100 := rel("E", "1.0.0", deps())
+	e101 := rel("E", "1.0.1", deps("F")) // INVALID
 	arch := &Archive{
 		Releases: map[string]Releases{
 			"B": {b131, b130, b121, b120, b111, b110, b100},
 			"C": {c200, c120, c111, c110, c102, c101, c100, c021, c020, c010},
 			"D": {d100, d120},
-			"E": {e100},
+			"E": {e100, e101},
 		},
 	}
 


### PR DESCRIPTION
This change speed up cases where a lot of dependencies are present but one is missing:

```
A
|__ B (1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4)
|__ C (1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4)
|__ D (1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4)
|__ E (1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4)
|__ F (1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4)
|__ G (1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4)
|__ H (1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4)
\__ I (dependency not available)
```

In this case the last dependency `I` can not be resolved, but it is checked as last. This means that the backtracking algorithm will check all the other branches first with exponential time complexity (in the case shown above it must check 5^7 combinations before giving up).