### PR TITLE
Speedup dependency resolver by analizying fruitless branches first

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -55,9 +55,28 @@ type Archive struct {
 // Resolve will try to depp-resolve dependencies from the Release passed as
 // arguent using a backtracking algorithm.
 func (ar *Archive) Resolve(release Release) []Release {
-	solution := map[string]Release{release.GetName(): release}
-	depsToProcess := release.GetDependencies()
-	return ar.resolve(solution, depsToProcess)
+	mainDep := &bareDependency{
+		name:    release.GetName(),
+		version: release.GetVersion(),
+	}
+	return ar.resolve(map[string]Release{}, []Dependency{mainDep})
+}
+
+type bareDependency struct {
+	name    string
+	version *Version
+}
+
+func (b *bareDependency) GetName() string {
+	return b.name
+}
+
+func (b *bareDependency) GetConstraint() Constraint {
+	return &Equals{Version: b.version}
+}
+
+func (b *bareDependency) String() string {
+	return b.GetName() + b.GetConstraint().String()
 }
 
 func (ar *Archive) resolve(solution map[string]Release, depsToProcess []Dependency) []Release {

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -74,6 +74,10 @@ func rel(name, ver string, deps []Dependency) Release {
 }
 
 func TestResolver(t *testing.T) {
+	a100 := rel("A", "1.0.0", deps("B>=1.2.0", "C>=2.0.0"))
+	a110 := rel("A", "1.1.0", deps("B=1.2.0", "C>=2.0.0"))
+	a111 := rel("A", "1.1.1", deps("B", "C=1.1.1"))
+	a120 := rel("A", "1.2.0", deps("B=1.2.0", "C>2.0.0"))
 	b131 := rel("B", "1.3.1", deps("C<2.0.0"))
 	b130 := rel("B", "1.3.0", deps())
 	b121 := rel("B", "1.2.1", deps())
@@ -97,6 +101,7 @@ func TestResolver(t *testing.T) {
 	e101 := rel("E", "1.0.1", deps("F")) // INVALID
 	arch := &Archive{
 		Releases: map[string]Releases{
+			"A": {a100, a110, a111, a120},
 			"B": {b131, b130, b121, b120, b111, b110, b100},
 			"C": {c200, c120, c111, c110, c102, c101, c100, c021, c020, c010},
 			"D": {d100, d120},
@@ -104,10 +109,9 @@ func TestResolver(t *testing.T) {
 		},
 	}
 
-	a100 := rel("A", "1.0.0", deps("B>=1.2.0", "C>=2.0.0"))
-	a110 := rel("A", "1.1.0", deps("B=1.2.0", "C>=2.0.0"))
-	a111 := rel("A", "1.1.1", deps("B", "C=1.1.1"))
-	a120 := rel("A", "1.2.0", deps("B=1.2.0", "C>2.0.0"))
+	a130 := rel("A", "1.3.0", deps())
+	r0 := arch.Resolve(a130) // Non-existent in archive
+	require.Nil(t, r0)
 
 	r1 := arch.Resolve(a100)
 	require.Len(t, r1, 3)

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -9,6 +9,7 @@ package semver
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -78,6 +79,7 @@ func TestResolver(t *testing.T) {
 	a110 := rel("A", "1.1.0", deps("B=1.2.0", "C>=2.0.0"))
 	a111 := rel("A", "1.1.1", deps("B", "C=1.1.1"))
 	a120 := rel("A", "1.2.0", deps("B=1.2.0", "C>2.0.0"))
+	a121 := rel("A", "1.2.1", deps("B", "C", "G", "H", "I", "E=1.0.1"))
 	b131 := rel("B", "1.3.1", deps("C<2.0.0"))
 	b130 := rel("B", "1.3.0", deps())
 	b121 := rel("B", "1.2.1", deps())
@@ -99,13 +101,34 @@ func TestResolver(t *testing.T) {
 	d120 := rel("D", "1.2.0", deps("E"))
 	e100 := rel("E", "1.0.0", deps())
 	e101 := rel("E", "1.0.1", deps("F")) // INVALID
+	g130 := rel("G", "1.3.0", deps())
+	g140 := rel("G", "1.4.0", deps())
+	g150 := rel("G", "1.5.0", deps())
+	g160 := rel("G", "1.6.0", deps())
+	g170 := rel("G", "1.7.0", deps())
+	g180 := rel("G", "1.8.0", deps())
+	h130 := rel("H", "1.3.0", deps())
+	h140 := rel("H", "1.4.0", deps())
+	h150 := rel("H", "1.5.0", deps())
+	h160 := rel("H", "1.6.0", deps())
+	h170 := rel("H", "1.7.0", deps())
+	h180 := rel("H", "1.8.0", deps())
+	i130 := rel("I", "1.3.0", deps())
+	i140 := rel("I", "1.4.0", deps())
+	i150 := rel("I", "1.5.0", deps())
+	i160 := rel("I", "1.6.0", deps())
+	i170 := rel("I", "1.7.0", deps())
+	i180 := rel("I", "1.8.0", deps())
 	arch := &Archive{
 		Releases: map[string]Releases{
-			"A": {a100, a110, a111, a120},
+			"A": {a100, a110, a111, a120, a121},
 			"B": {b131, b130, b121, b120, b111, b110, b100},
 			"C": {c200, c120, c111, c110, c102, c101, c100, c021, c020, c010},
 			"D": {d100, d120},
 			"E": {e100, e101},
+			"G": {g130, g140, g150, g160, g170, g180},
+			"H": {h130, h140, h150, h160, h170, h180},
+			"I": {i130, i140, i150, i160, i170, i180},
 		},
 	}
 
@@ -143,4 +166,17 @@ func TestResolver(t *testing.T) {
 	require.Contains(t, r5, d120)
 	require.Contains(t, r5, e100)
 	fmt.Println(r5)
+
+	done := make(chan bool)
+	go func() {
+		r6 := arch.Resolve(a121)
+		require.Nil(t, r6)
+		fmt.Println(r6)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		require.FailNow(t, "test didn't complete in the allocated time")
+	}
 }


### PR DESCRIPTION
This change helps not to get stuck in a loop when analyzing cases similar to #14 but with the unsuccessful branch that can not be pre-cut because buried deep in the dependency tree:

```
A
\__ B (1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4)
     \__ C (1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4)
          \__ D (1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4)
          \__ E (1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4)
          \__ F (1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4)
          \__ G (1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4)
          \__ H (1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4)
          \__ I (dependency not available)
```

BTW this change does not fix the worst case, it moves it further away, but it's still possible.
A better strategy must be implemented for more complex scenarios.
