### PR TITLE
Generics-based resolver

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -130,20 +130,16 @@ func (ar *Resolver[R, D]) resolve(solution map[string]R, depsToProcess []D, prob
 	releases.SortDescent()
 
 	debug("releases matching criteria: %s", releases)
+backtracking_loop:
 	for _, release := range releases {
-		deps := release.GetDependencies()
-		debug("try with %s %s", release, deps)
+		releaseDeps := release.GetDependencies()
+		debug("try with %s %s", release, releaseDeps)
 
-		missingDep := false
-		for _, dep := range deps {
-			if _, ok := ar.releases[dep.GetName()]; !ok {
-				debug("%s did not work, becuase his dependency %s does not exists", release, dep.GetName())
-				missingDep = true
-				break
+		for _, releaseDep := range releaseDeps {
+			if _, ok := ar.releases[releaseDep.GetName()]; !ok {
+				debug("%s did not work, becuase his dependency %s does not exists", release, releaseDep.GetName())
+				continue backtracking_loop
 			}
-		}
-		if missingDep {
-			continue
 		}
 
 		solution[depName] = release

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -19,10 +19,12 @@ type customDep struct {
 	cond Constraint
 }
 
+// GetName return the name of the dependency (implements the Dependency interface)
 func (c *customDep) GetName() string {
 	return c.name
 }
 
+// GetConstraint return the version contraints of the dependency (implements the Dependency interface)
 func (c *customDep) GetConstraint() Constraint {
 	return c.cond
 }
@@ -34,18 +36,20 @@ func (c *customDep) String() string {
 type customRel struct {
 	name string
 	vers *Version
-	deps []Dependency
+	deps []*customDep
 }
 
+// GetName return the name of the release (implements the Release interface)
 func (r *customRel) GetName() string {
 	return r.name
 }
 
+// GetVersion return the version of the release (implements the Release interface)
 func (r *customRel) GetVersion() *Version {
 	return r.vers
 }
 
-func (r *customRel) GetDependencies() []Dependency {
+func (r *customRel) GetDependencies() []*customDep {
 	return r.deps
 }
 
@@ -53,7 +57,7 @@ func (r *customRel) String() string {
 	return r.name + "@" + r.vers.String()
 }
 
-func d(dep string) Dependency {
+func d(dep string) *customDep {
 	name := dep[0:1]
 	cond, err := ParseConstraint(dep[1:])
 	if err != nil {
@@ -62,15 +66,15 @@ func d(dep string) Dependency {
 	return &customDep{name: name, cond: cond}
 }
 
-func deps(deps ...string) []Dependency {
-	res := []Dependency{}
+func deps(deps ...string) []*customDep {
+	var res []*customDep
 	for _, dep := range deps {
 		res = append(res, d(dep))
 	}
 	return res
 }
 
-func rel(name, ver string, deps []Dependency) Release {
+func rel(name, ver string, deps []*customDep) *customRel {
 	return &customRel{name: name, vers: v(ver), deps: deps}
 }
 
@@ -119,18 +123,17 @@ func TestResolver(t *testing.T) {
 	i160 := rel("I", "1.6.0", deps())
 	i170 := rel("I", "1.7.0", deps())
 	i180 := rel("I", "1.8.0", deps())
-	arch := &Archive{
-		Releases: map[string]Releases{
-			"A": {a100, a110, a111, a120, a121},
-			"B": {b131, b130, b121, b120, b111, b110, b100},
-			"C": {c200, c120, c111, c110, c102, c101, c100, c021, c020, c010},
-			"D": {d100, d120},
-			"E": {e100, e101},
-			"G": {g130, g140, g150, g160, g170, g180},
-			"H": {h130, h140, h150, h160, h170, h180},
-			"I": {i130, i140, i150, i160, i170, i180},
-		},
-	}
+	arch := NewArchive[*customRel, *customDep]()
+	arch.AddReleases(
+		a100, a110, a111, a120, a121,
+		b131, b130, b121, b120, b111, b110, b100,
+		c200, c120, c111, c110, c102, c101, c100, c021, c020, c010,
+		d100, d120,
+		e100, e101,
+		g130, g140, g150, g160, g170, g180,
+		h130, h140, h150, h160, h170, h180,
+		i130, i140, i150, i160, i170, i180,
+	)
 
 	a130 := rel("A", "1.3.0", deps())
 	r0 := arch.Resolve(a130) // Non-existent in archive
@@ -179,4 +182,7 @@ func TestResolver(t *testing.T) {
 	case <-time.After(time.Second):
 		require.FailNow(t, "test didn't complete in the allocated time")
 	}
+
+	r7 := arch.Resolve(e101)
+	require.Nil(t, r7)
 }

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -123,7 +123,7 @@ func TestResolver(t *testing.T) {
 	i160 := rel("I", "1.6.0", deps())
 	i170 := rel("I", "1.7.0", deps())
 	i180 := rel("I", "1.8.0", deps())
-	arch := NewArchive[*customRel, *customDep]()
+	arch := NewResolver[*customRel, *customDep]()
 	arch.AddReleases(
 		a100, a110, a111, a120, a121,
 		b131, b130, b121, b120, b111, b110, b100,

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -129,11 +129,12 @@ func TestResolver(t *testing.T) {
 		b131, b130, b121, b120, b111, b110, b100,
 		c200, c120, c111, c110, c102, c101, c100, c021, c020, c010,
 		d100, d120,
-		e100, e101,
 		g130, g140, g150, g160, g170, g180,
 		h130, h140, h150, h160, h170, h180,
 		i130, i140, i150, i160, i170, i180,
 	)
+	arch.AddRelease(e100) // use this method for 100% code coverage
+	arch.AddRelease(e101)
 
 	a130 := rel("A", "1.3.0", deps())
 	r0 := arch.Resolve(a130) // Non-existent in archive


### PR DESCRIPTION
This PR provides a Resolver object that can be used to resolve dependencies without the need for the caller to box/unbox his concrete structs into `semver.Release` and `semver.Dependency` interfaces.

The old way required something like this:

```go
	type customRel struct {
		...
		Deps []semver.Dependency
	}
	a100 := &customRel{...., Deps: []*customDep{....} } // Boxing *customDep into sermver.Dependecy
	a110 := &customRel{...., Deps: []*customDep{....} }
	a120 := &customRel{...., Deps: []*customDep{....} }
	arch := &Archive{
		Releases: map[string]Releases{
			"A": {a100, a110, a111, a120, a121},   // Boxing *customRel into semver.Release
			"B": {b131, b130, b121, b120, b111, b110, b100},
			"C": {c200, c120, c111, c110, c102, c101, c100, c021, c020, c010},
			"D": {d100, d120},
			"E": {e100, e101},
			"G": {g130, g140, g150, g160, g170, g180},
			"H": {h130, h140, h150, h160, h170, h180},
			"I": {i130, i140, i150, i160, i170, i180},
		},
	}
	boxedRes := arch.Resolve(...)
	res := []*customRel{}
	for _, r := range res {
		res = append(res, *customRel(r))  // Unbox semver.Release into *customRel
	}
```

now we can avoid type conversion using the generic constructor:

```go
	a100 := &customRel{.... &customDep{....} }
	a110 := &customRel{.... &customDep{....} }
	a120 := &customRel{.... &customDep{....} }
	// ...
	arch := NewResolver[*customRel, *customDep]() // Specify custom types using generics declaration
	arch.AddReleases(   // No need to box in semver.Release interface
		a100, a110, a111, a120, a121,
		b131, b130, b121, b120, b111, b110, b100,
		c200, c120, c111, c110, c102, c101, c100, c021, c020, c010,
		d100, d120,
		e100, e101,
		g130, g140, g150, g160, g170, g180,
		h130, h140, h150, h160, h170, h180,
		i130, i140, i150, i160, i170, i180,
	)

	res := arch.Resolve(....) // res is already a []*customRel, no need to unbox
```