### PR TITLE
Fix extreme compares with "relaxed" versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,6 +37,9 @@ jobs:
       - name: Run unit tests with coverage
         run: go test -v -race -covermode=atomic -coverprofile=coverage.out ./...
         shell: bash
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v5
         with:
           verbose: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        

--- a/version.go
+++ b/version.go
@@ -133,9 +133,9 @@ func (v *Version) CompareTo(u *Version) int {
 				return -1
 			}
 		} else if vMajor == 0 && u.bytes[uIdx] == '0' {
-			return 0
+			// continue
 		} else if uMajor == 0 && v.bytes[vIdx] == '0' {
-			return 0
+			// continue
 		} else if vMajor > uMajor {
 			return 1
 		} else {
@@ -162,9 +162,9 @@ func (v *Version) CompareTo(u *Version) int {
 				return -1
 			}
 		} else if vMinor == vMajor && u.bytes[uIdx] == '0' {
-			return 0
+			// continue
 		} else if uMinor == uMajor && v.bytes[vIdx] == '0' {
-			return 0
+			// continue
 		} else if la > lb {
 			return 1
 		} else {

--- a/version_test.go
+++ b/version_test.go
@@ -80,7 +80,19 @@ func TestVersionComparator(t *testing.T) {
 			}
 		}
 	}
+	ascending(t, false, "", "0.0.1")
+	ascending(t, false, "", "0.1")
+	ascending(t, false, "", "1")
+	ascending(t, false, "0", "0.0.1")
+	ascending(t, false, "0", "0.1")
+	ascending(t, false, "0", "1")
+	ascending(t, false, "0.0", "0.0.1")
+	ascending(t, false, "0.0", "0.1")
+	ascending(t, false, "0.0", "1")
 	ascending(t, false,
+		"",
+		"0.0.1",
+		"0.1",
 		"1.0.0-2",
 		"1.0.0-11",
 		"1.0.0-11a",


### PR DESCRIPTION
Fixed the `CompareTo` method in some extreme cases:

```
"" < "0.0.1"
"0" < "0.0.1"
"0.0" < "0.0.1"
```
