### PR TITLE
Made Version.SortableString() comparable directly with RelaxedVersion.SortableString()

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,22 +113,22 @@ This is accomplished by adding some adjustment characters to the original semver
 
 To give you an idea on how it works, the following table shows some examples of semver versions and their `SortableString` counter part:
 
-| semver             | `SortableString()` |
-| ------------------ | ------------------ |
-| `1.2.4`            | `1.2.4;`           |
-| `1.3.0-rc`         | `1.3.0-;rc`        |
-| `1.3.0-rc.0`       | `1.3.0-;rc,:0`     |
-| `1.3.0-rc.5`       | `1.3.0-;rc,:5`     |
-| `1.3.0-rc.5+build` | `1.3.0-;rc,:5`     |
-| `1.3.0-rc.20`      | `1.3.0-;rc,::20`   |
-| `1.3.0-rc-`        | `1.3.0-;rc-`       |
-| `1.3.0`            | `1.3.0;`           |
-| `1.20.0`           | `1.:20.0;`         |
-| `1.90.0`           | `1.:90.0;`         |
-| `1.300.0-6`        | `1.::300.0-:6`     |
-| `1.300.0-30`       | `1.::300.0-::30`   |
-| `1.300.0-1pre`     | `1.::300.0-;1pre`  |
-| `1.300.0-pre`      | `1.::300.0-;pre`   |
-| `1.300.0`          | `1.::300.0;`       |
+| semver             | `SortableString()`  |
+| ------------------ | ------------------- |
+| `1.2.4`            | `;1.2.4;`           |
+| `1.3.0-rc`         | `;1.3.0-;rc`        |
+| `1.3.0-rc.0`       | `;1.3.0-;rc,:0`     |
+| `1.3.0-rc.5`       | `;1.3.0-;rc,:5`     |
+| `1.3.0-rc.5+build` | `;1.3.0-;rc,:5`     |
+| `1.3.0-rc.20`      | `;1.3.0-;rc,::20`   |
+| `1.3.0-rc-`        | `;1.3.0-;rc-`       |
+| `1.3.0`            | `;1.3.0;`           |
+| `1.20.0`           | `;1.:20.0;`         |
+| `1.90.0`           | `;1.:90.0;`         |
+| `1.300.0-6`        | `;1.::300.0-:6`     |
+| `1.300.0-30`       | `;1.::300.0-::30`   |
+| `1.300.0-1pre`     | `;1.::300.0-;1pre`  |
+| `1.300.0-pre`      | `;1.::300.0-;pre`   |
+| `1.300.0`          | `;1.::300.0;`       |
 
 The `SortableString()` can be used in SQL databases to simplify the ordering of a set of versions in a table.

--- a/relaxed_version.go
+++ b/relaxed_version.go
@@ -114,7 +114,7 @@ func (v *RelaxedVersion) CompatibleWith(u *RelaxedVersion) bool {
 // introduced in a system that doesn't support semver ordering.
 func (v *RelaxedVersion) SortableString() string {
 	if v.version != nil {
-		return ";" + v.version.SortableString()
+		return v.version.SortableString()
 	}
 	return ":" + string(v.customversion)
 }

--- a/version.go
+++ b/version.go
@@ -455,7 +455,7 @@ func (v *Version) SortableString() string {
 		vPatch = v.bytes[v.minor+1 : v.patch]
 	}
 
-	res := encodeNumber(vMajor) + "." + encodeNumber(vMinor) + "." + encodeNumber(vPatch)
+	res := ";" + encodeNumber(vMajor) + "." + encodeNumber(vMinor) + "." + encodeNumber(vPatch)
 	// If there is no pre-release, add a ";" to the end, otherwise add a "-" followed by the pre-release.
 	// This ensure the correct ordering of the pre-release versions (that are always lower than the normal versions).
 	if v.prerelease == v.patch {


### PR DESCRIPTION
Previously comparing a sortable string from a Version and a RelaxedVersion may have an undefined outcome.
Now it's possible to compare the sortable strings directly.
This is a breaking change, if a previous Version.SortableString() has been stored on the DB, it must be regenerated.
